### PR TITLE
Донастройка линтеров в CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,7 @@
 [flake8]
 max-doc-length = 88
 max-line-length = 88
+ignore = D104,D107,W503
 extend-ignore = E203
+per-file-ignores =
+    test*:D101,D102,D103

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,10 @@ build-backend = "poetry.core.masonry.api"
 [tool.vulture]
 min_confidence = 70
 paths = ["."]
+
+# https://mypy.readthedocs.io/en/stable/config_file.html#example-pyproject-toml
+[[tool.mypy.overrides]]
+module = [
+    "tests.*",
+]
+ignore_errors = true


### PR DESCRIPTION
Исключил папку tests из проверки mypy'ем.
Выключил ошибки D104, D107,W503 flake8 для всех файлов:
    D104 - Missing docstring in public package
    D107 - Missing docstring in __init__
    W503 - Line break occurred before a binary operator
    
и D101,D102,D103 для папки tests:
    D101 - Missing docstring in public class
    D102 - Missing docstring in public method
    D103 - Missing docstring in public function